### PR TITLE
lcb.lambda can be taken as parameter of rexp in multipoint

### DIFF
--- a/R/getExtras.R
+++ b/R/getExtras.R
@@ -23,13 +23,11 @@ getExtras = function(n, prop, train.time, control) {
       names(ex)[1] = control$infill.crit
     }
     # if we use singlecrit parallel LCB store lambdas
-    if (control$propose.points > 1L &&
-        (control$number.of.targets == 1L && control$multipoint.method == "lcb")) {
-
-      lams = prop$multipoint.lcb.lambdas
+    if (!is.null(control$multipoint.method) && control$number.of.targets == 1L && control$multipoint.method == "lcb") {
+      lams = prop$lcb.lambdas
       if (is.null(lams))
         lams = rep(NA_real_, n)
-      ex$multipoint.lcb.lambda = lams[i]
+      ex$lcb.lambda = lams[i]
     }
     # if we use parego, store weights
     if (control$number.of.targets > 1L && control$multicrit.method == "parego") {

--- a/R/proposePointsDIB.R
+++ b/R/proposePointsDIB.R
@@ -41,7 +41,7 @@ proposePointsDIB = function(opt.state) {
     # store extra info
     # DH: don't to this for now
     # FIXME: do we want to sample or adapt lamda here? decide
-    #res$multipoint.lcb.lambdas = z$lambdas
+    #res$lcb.lambdas = z$lambdas
   }
   return(res)
 }

--- a/R/proposePointsHelpers.R
+++ b/R/proposePointsHelpers.R
@@ -31,7 +31,7 @@ checkFailedModels = function(models, par.set, npoints, control) {
 
 # create control objects with random lamda values for parallel LCB multi-point
 createRandomLCBControls = function(control, crit, user.lambda = FALSE) {
-  lambdas = rexp(control$propose.points)
+  lambdas = rexp(control$propose.points, 1/control$infill.crit.lcb.lambda)
   controls = lapply(lambdas, function(lambda) {
     ctrl = control;
     ctrl$propose.points = 1L;

--- a/R/proposePointsParallelLCB.R
+++ b/R/proposePointsParallelLCB.R
@@ -10,7 +10,7 @@ proposePointsParallelLCB = function(opt.state) {
     more.args = list(opt.state = opt.state))
 
   res = joinProposedPoints(props)
-  res$multipoint.lcb.lambdas = z$lambdas
+  res$lcb.lambdas = z$lambdas
   return(res)
 }
 

--- a/R/setMBOControlInfill.R
+++ b/R/setMBOControlInfill.R
@@ -21,6 +21,7 @@
 #'   Default is 0.75.
 #' @param crit.lcb.lambda [\code{numeric(1)}]\cr
 #'   Lambda parameter for lower confidence bound infill criterion.
+#'   If you use \code{lcb} as a \code{MultiPoint} method, this value will be the expected value of the exponential distribution from which the multiple lambda parameters will be drawn.
 #'   Only used if \code{crit == "lcb"}, ignored otherwise.
 #'   Default is 1.
 # FIXME: does this only make sense for multicrit? or single crit too?

--- a/man/setMBOControlInfill.Rd
+++ b/man/setMBOControlInfill.Rd
@@ -43,6 +43,7 @@ Default is 0.75.}
 
 \item{crit.lcb.lambda}{[\code{numeric(1)}]\cr
 Lambda parameter for lower confidence bound infill criterion.
+If you use \code{lcb} as a \code{MultiPoint} method, this value will be the expected value of the exponential distribution from which the multiple lambda parameters will be drawn.
 Only used if \code{crit == "lcb"}, ignored otherwise.
 Default is 1.}
 

--- a/tests/testthat/test_infillcrits.R
+++ b/tests/testthat/test_infillcrits.R
@@ -62,6 +62,14 @@ test_that("infill crits", {
     opt.focussearch.points = 300L, crit.lcb.lambda = NULL, crit.lcb.pi = 0.5)
   or = mbo(f, ps, NULL, makeLearner("regr.km", predict.type = "se"), ctrl)
   expect_true(or$y < 50)
+  
+  # check random lambda
+  ctrl = makeMBOControl(minimize = TRUE, init.design.points = 5L, iters = 10L, propose.points = 1L)
+  ctrl = setMBOControlInfill(ctrl, crit = "lcb", opt = "focussearch", opt.restarts = 1L,
+                             opt.focussearch.points = 300L, crit.lcb.lambda = 0.25)
+  ctrl = setMBOControlMultiPoint(ctrl, method = "lcb")
+  or = mbo(f, ps, NULL, makeLearner("regr.km", predict.type = "se"), ctrl)
+  abs(1 / mean(as.data.frame(or$opt.path)$lcb.lambda, na.rm = TRUE) - 0.25) < 0.5
 
   # check beta for eqi
   expect_error(setMBOControlInfill(ctrl, crit = "eqi", opt = "focussearch", opt.restarts = 1L,

--- a/tests/testthat/test_multipoint_lcb.R
+++ b/tests/testthat/test_multipoint_lcb.R
@@ -14,8 +14,8 @@ test_that("multipoint lcb", {
 
   res = mbo(makeMBOFunction(objfun), par.set = ps, learner = lrn, control = ctrl)
   op = as.data.frame(res$opt.path)
-  expect_true(all(is.na(op$multipoint.lcb.lambda[1:30])))
-  expect_true(all(!is.na(op$multipoint.lcb.lambda[31:35])))
+  expect_true(all(is.na(op$lcb.lambda[1:30])))
+  expect_true(all(!is.na(op$lcb.lambda[31:35])))
   expect_is(res, "MBOResult")
   expect_true(res$y < 0.1)
 

--- a/todo-files/exampleRun_plot_1d_numeric.R
+++ b/todo-files/exampleRun_plot_1d_numeric.R
@@ -70,7 +70,7 @@ plotMBOExampleRun1DNumeric = function(x, iters, pause=TRUE,
           for (j in 1:proppoints) {
             #FIXME works only for lcb
             ctrl2 = ctrl
-            ctrl2$infill.crit.lcb.lambda = mr$multipoint.lcb.lambdas[i, j]
+            ctrl2$infill.crit.lcb.lambda = mr$lcb.lambdas[i, j]
             evals[[sprintf("%s_%i", "lcb", j)]] =
               opt.direction * infillCritLCB(evals.x,
                 mod, ctrl2, par.set, op[ind.pasdes, ])

--- a/todo-files/exampleRun_plot_2d_numeric.R
+++ b/todo-files/exampleRun_plot_2d_numeric.R
@@ -97,7 +97,7 @@ plotMBOExampleRun2DNumeric = function(x, iters, pause=TRUE,
     } else {
       # just display the first lcb crit fun
       ctrl2 = ctrl
-      ctrl2$infill.crit.lcb.lambda = mr$multipoint.lcb.lambdas[i, 1]
+      ctrl2$infill.crit.lcb.lambda = mr$lcb.lambdas[i, 1]
       evals[[name.crit]] = opt.direction * infillCritLCB(evals[, names.x, drop=FALSE],
         mod, ctrl, par.set, op[ind.pasdes, ])
     }


### PR DESCRIPTION
To obtain randomly choosen lambdas we use the multipoint method as a shortcut. 