### PR TITLE
Fix #145: Direction of yhat has to be turned again

### DIFF
--- a/R/renderExampleRunPlotSingleCrit1d.R
+++ b/R/renderExampleRunPlotSingleCrit1d.R
@@ -86,9 +86,8 @@ renderExampleRunPlot1d = function(x, iter,
 
   # compute model prediction for current iter
   if (!inherits(model, "FailureModel")) {
-    evals$yhat = infillCritMeanResponse(evals.x, list(model),
-      control, par.set, convertOptPathToDf(opt.path, control)[idx.past, ])
-
+    evals$yhat = ifelse(control$minimize, 1, -1) * infillCritMeanResponse(evals.x, list(model), control)
+    
     #FIXME: We might want to replace the following by a helper function so that we can reuse it in buildPointsData()
     if (propose.points == 1L) {
       evals[[name.crit]] = opt.direction *

--- a/R/renderExampleRunPlotSingleCrit2d.R
+++ b/R/renderExampleRunPlotSingleCrit2d.R
@@ -59,7 +59,7 @@ renderExampleRunPlot2d = function(x, iter,
   model.ok = !inherits(models[[1L]], "FailureModel")
 
   if (model.ok) {
-    evals$yhat = infillCritMeanResponse(evals.x, models, control, par.set, opt.path[idx.past, ])
+    evals$yhat = ifelse(control$minimize, 1, -1) * infillCritMeanResponse(evals.x, models, control, par.set, opt.path[idx.past, ])
     if (se) {
       evals$se = -infillCritStandardError(evals.x, models, control, par.set, opt.path[idx.past, ])
     }


### PR DESCRIPTION
Checked it manually for ex_1d_numeric and ex_2d_numeric. No further calls of `infillCritMeanResponse` found.