### PR TITLE
small changes to exampleRunMulticrit example: now 3D y-space

### DIFF
--- a/inst/examples/ex_multicrit_plots.R
+++ b/inst/examples/ex_multicrit_plots.R
@@ -6,10 +6,10 @@ set.seed(1)
 configureMlr(show.learner.output = FALSE)
 pause = interactive()
 
-obj.fun = makeZDT1Function(dimensions = 5L)
+obj.fun = makeDTLZ1Function(dimensions = 5L, n.objectives = 3L)
 
 lrn = makeLearner("regr.km", predict.type = "se")
-ctrl = makeMBOControl(number.of.targets = 2L,
+ctrl = makeMBOControl(number.of.targets = 3L,
   propose.points = 2L)
 ctrl = setMBOControlTermination(ctrl, iters = 10L)
 ctrl = setMBOControlInfill(ctrl, crit = "ei", opt.focussearch.points = 1000L,

--- a/tests/testthat/test_exampleRunMulticrit.R
+++ b/tests/testthat/test_exampleRunMulticrit.R
@@ -2,7 +2,7 @@ context("exampleRunMulticrit")
 
 test_that("exampleRunMulticrit", {
 
-  doRun = function(fun, method, crit, prop.points, indicator = "sms") {
+  doRun = function(method, crit, prop.points, indicator = "sms") {
     # set nugget effect to small value for num stability in this unit test
     learner = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2", nugget = 0.001)
     control = makeMBOControl(number.of.targets = 2L,
@@ -21,16 +21,16 @@ test_that("exampleRunMulticrit", {
     res = renderExampleRunPlot(run, iter = 1L)
   }
 
-  doRun(fun1, method = "parego", crit = "ei", prop.points = 1L)
-  doRun(fun1, method = "parego", crit = "ei", prop.points = 2L)
-  doRun(fun1, method = "parego", crit = "cb", prop.points = 1L)
-  doRun(fun1, method = "parego", crit = "cb", prop.points = 2L)
-  doRun(fun1, method = "mspot", crit = "ei", prop.points = 1L)
-  doRun(fun1, method = "mspot", crit = "ei", prop.points = 2L)
-  doRun(fun1, method = "mspot", crit = "cb", prop.points = 1L)
-  doRun(fun1, method = "mspot", crit = "cb", prop.points = 2L)
-  doRun(fun1, method = "dib", crit = "dib", prop.points = 1L)
-  doRun(fun1, method = "dib", crit = "dib", prop.points = 2L)
-  doRun(fun1, method = "dib", crit = "dib", prop.points = 1L, indicator = "eps")
-  doRun(fun1, method = "dib", crit = "dib", prop.points = 2L, indicator = "eps")
+  doRun(method = "parego", crit = "ei", prop.points = 1L)
+  doRun(method = "parego", crit = "ei", prop.points = 2L)
+  doRun(method = "parego", crit = "cb", prop.points = 1L)
+  doRun(method = "parego", crit = "cb", prop.points = 2L)
+  doRun(method = "mspot", crit = "ei", prop.points = 1L)
+  doRun(method = "mspot", crit = "ei", prop.points = 2L)
+  doRun(method = "mspot", crit = "cb", prop.points = 1L)
+  doRun(method = "mspot", crit = "cb", prop.points = 2L)
+  doRun(method = "dib", crit = "dib", prop.points = 1L)
+  doRun(method = "dib", crit = "dib", prop.points = 2L)
+  doRun(method = "dib", crit = "dib", prop.points = 1L, indicator = "eps")
+  doRun(method = "dib", crit = "dib", prop.points = 2L, indicator = "eps")
 })


### PR DESCRIPTION
Just a small change in order to show, that exampleRunMulticrit works for objective space with dimension > 2 as well. 