### PR TITLE
Fix #199: register parallelMap levels in .onLoad

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,6 +9,6 @@
 #' @useDynLib mlrMBO c_sms_indicator c_eps_indicator
 NULL
 
-.onAttach = function(libname, pkgname) {
+.onLoad = function(libname, pkgname) {
   parallelRegisterLevels(package = "mlrMBO", levels = c("propose.points", "feval"))
 }


### PR DESCRIPTION
parallelRegisterLevels was in .onAttach; but this doesn't always get executed when the mlrMBO namespace is loaded.