### PR TITLE
Remove default for iters in setMBOControlTermination

### DIFF
--- a/R/setMBOControlTermination.R
+++ b/R/setMBOControlTermination.R
@@ -6,7 +6,6 @@
 #' @template arg_control
 #' @param iters [\code{integer(1)}]\cr
 #'   Number of sequential optimization steps.
-#'   Default is 10.
 #' @param time.budget [\code{integer(1)} | NULL]\cr
 #'   Running time budget in seconds. Note that the actual mbo run can take more time since
 #'   the condition is checked after each iteration.
@@ -56,7 +55,7 @@
 #' @family MBOControl
 #' @export
 setMBOControlTermination = function(control,
-  iters = 10L, time.budget = NULL, exec.time.budget = NULL, target.fun.value = NULL, max.evals = NULL, more.stop.conds = list()) {
+  iters = NULL, time.budget = NULL, exec.time.budget = NULL, target.fun.value = NULL, max.evals = NULL, more.stop.conds = list()) {
 
   assertList(more.stop.conds)
 

--- a/man/setMBOControlTermination.Rd
+++ b/man/setMBOControlTermination.Rd
@@ -4,7 +4,7 @@
 \alias{setMBOControlTermination}
 \title{Set termination options.}
 \usage{
-setMBOControlTermination(control, iters = 10L, time.budget = NULL,
+setMBOControlTermination(control, iters = NULL, time.budget = NULL,
   exec.time.budget = NULL, target.fun.value = NULL, max.evals = NULL,
   more.stop.conds = list())
 }
@@ -13,8 +13,7 @@ setMBOControlTermination(control, iters = 10L, time.budget = NULL,
 Control object for mbo.}
 
 \item{iters}{[\code{integer(1)}]\cr
-Number of sequential optimization steps.
-Default is 10.}
+Number of sequential optimization steps.}
 
 \item{time.budget}{[\code{integer(1)} | NULL]\cr
 Running time budget in seconds. Note that the actual mbo run can take more time since

--- a/tests/testthat/test_initdesign.R
+++ b/tests/testthat/test_initdesign.R
@@ -12,7 +12,6 @@ test_that("init design", {
 
   learner = makeLearner("regr.km", nugget.estim = TRUE)
   ctrl = makeMBOControl()
-  ctrl = setMBOControlTermination(ctrl)
   ctrl = setMBOControlTermination(ctrl, iters = 1L)
   ctrl = setMBOControlInfill(ctrl, opt.focussearch.points = 10L)
 


### PR DESCRIPTION
[Continuation of Issue #210]

The 10 Is just arbitrary anyway. The user should now what he is doing here so no defaults are necessary.   What's your opinion?