### PR TITLE
noisy and minimize should be set before checkLeaner

### DIFF
--- a/R/exampleRun.R
+++ b/R/exampleRun.R
@@ -38,6 +38,8 @@ exampleRun = function(fun, design = NULL, learner = NULL, control,
   par.types = getParamTypes(par.set)
   n.params = sum(getParamLengths(par.set))
   noisy = isNoisy(fun)
+  control$noisy = noisy
+  control$minimize = shouldBeMinimized(fun)
   learner = checkLearner(learner, par.set, control)
   assertClass(control, "MBOControl")
   points.per.dim = asCount(points.per.dim, positive = TRUE)
@@ -51,8 +53,6 @@ exampleRun = function(fun, design = NULL, learner = NULL, control,
     global.opt = smoof::getGlobalOptimum(fun)$value
   else
     global.opt = NA_real_
-  control$noisy = noisy
-  control$minimize = shouldBeMinimized(fun)
 
   if (control$n.objectives != 1L)
     stopf("exampleRun can only be applied for single objective functions, but you have %i objectives! Use 'exampleRunMultiCrit'!",


### PR DESCRIPTION
If `noisy` and `minimize` aren't set in the control object before `checkLeaner`, it will throw an error.

Now `exampleRun` seems to work