### PR TITLE
fix #222, missing unit test for PR219

### DIFF
--- a/tests/testthat/test_exampleRun.R
+++ b/tests/testthat/test_exampleRun.R
@@ -6,7 +6,8 @@ test_that("renderExampleRunPlot produces list of ggplot2 objects", {
   n.iters = 1L
 
   doRun = function(obj.fn, predict.type, crit, learner = "regr.km") {
-    learner = makeLearner(learner, predict.type = predict.type)
+    if (!is.null(learner))
+      learner = makeLearner(learner, predict.type = predict.type)
     control = makeMBOControl()
     control = setMBOControlTermination(control, iters = n.iters)
     control = setMBOControlInfill(control, crit = crit, opt = "focussearch", opt.focussearch.points = 10)
@@ -41,6 +42,10 @@ test_that("renderExampleRunPlot produces list of ggplot2 objects", {
 
   # with se
   plot.list = doRun(obj.fn, "se", "ei")
+  checkPlotList(plot.list)
+  
+  #default learner
+  plot.list = doRun(obj.fn, "response", "ei", learner = NULL)
   checkPlotList(plot.list)
 
 


### PR DESCRIPTION
Added a unit test for PR #219 

This checks if the default learner can be used for `exampleRun` and is not crashing because lrn$noisy is called. 