### PR TITLE
another clean up of tests after smoof changes

### DIFF
--- a/R/setMBOControlMultiPoint.R
+++ b/R/setMBOControlMultiPoint.R
@@ -112,8 +112,5 @@ setMBOControlMultiPoint = function(control,
   control$multipoint.multicrit.pm.p = coalesce(multicrit.pm.p, control$multipoint.multicrit.pm.p, 1)
   assertNumber(control$multipoint.multicrit.pm.p, na.ok = FALSE, lower = 0, upper = 1)
 
-  # FIXME: this is currently a hidden option, also see multipoint_cb.R
-  control$cb.min.dist = 1e-5
-
   return(control)
 }

--- a/tests/testthat/helper_objects.R
+++ b/tests/testthat/helper_objects.R
@@ -19,6 +19,8 @@ testf.zdt1.2d = makeZDT1Function(dimensions = 2L)
 testp.zdt1.2d = getParamSet(testf.zdt1.2d)
 testd.zdt1.2d = generateTestDesign(10L, testp.zdt1.2d)
 
+default.kriging = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
+
 testfmco1 = makeMultiObjectiveFunction(
   fn = function(x) x^2,
   n.objectives = 2L,

--- a/tests/testthat/test_exampleRun.R
+++ b/tests/testthat/test_exampleRun.R
@@ -90,9 +90,7 @@ test_that("renderExampleRunPlot produces list of ggplot2 objects", {
     multicrit.maxit = 200L
   )
 
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
-
-  run = exampleRun(obj.fun, learner = lrn, control = ctrl, points.per.dim = 50L)
+  run = exampleRun(obj.fun, learner = default.kriging, control = ctrl, points.per.dim = 50L)
 
   plot.list = renderExampleRunPlot(run, iter = 1L)
   checkPlotList(plot.list)

--- a/tests/testthat/test_infill_opt_ea.R
+++ b/tests/testthat/test_infill_opt_ea.R
@@ -9,10 +9,8 @@ test_that("infillopt ea", {
   ctrl = setMBOControlInfill(ctrl, crit = "ei", opt = "ea", opt.restarts = 2L,
     opt.ea.maxit = 75L, opt.ea.lambda = 1L)
 
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
-
   des = generateTestDesign(20L, smoof::getParamSet(obj.fun))
-  res = mbo(obj.fun, des, learner = lrn, control = ctrl)
+  res = mbo(obj.fun, des, learner = default.kriging, control = ctrl)
   expect_true(res$y < 1e-1)
 
   obj.fun = smoof::makeSingleObjectiveFunction(
@@ -25,6 +23,6 @@ test_that("infillopt ea", {
   )
 
   des = generateTestDesign(10L, smoof::getParamSet(obj.fun))
-  res = mbo(obj.fun, des, learner = lrn, control = ctrl)
+  res = mbo(obj.fun, des, learner = default.kriging, control = ctrl)
   expect_true(res$y < 1e-1)
 })

--- a/tests/testthat/test_mbo_km.R
+++ b/tests/testthat/test_mbo_km.R
@@ -1,31 +1,23 @@
 context("mbo km")
 
 test_that("mbo works with km", {
-  par.set = makeParamSet(
-    makeNumericParam("x1", lower = -2, upper = 1),
-    makeNumericParam("x2", lower = -1, upper = 2)
-  )
-  f = makeSingleObjectiveFunction(
-    fn = function(x) sum(x^2),
-    par.set = par.set
-  )
-  des = generateTestDesign(10, par.set = smoof::getParamSet(f))
-  y = sapply(1:nrow(des), function(i) f(as.list(des[i, ])))
-  des$y = y
+  des = testd.fsphere.2d
+  des$y = apply(des, 1, testf.fsphere.2d)
   learner = makeLearner("regr.km", nugget.estim = TRUE)
   ctrl = makeMBOControl()
   ctrl = setMBOControlTermination(ctrl, iters = 5L)
   ctrl = setMBOControlInfill(ctrl, opt.focussearch.points = 100L)
-  or = mbo(f, des, learner = learner, control = ctrl)
+  or = mbo(testf.fsphere.2d, des, learner = learner, control = ctrl)
   expect_true(!is.na(or$y))
   expect_equal(getOptPathLength(or$opt.path), 15L)
   df = as.data.frame(or$opt.path)
   expect_true(is.numeric(df$x1))
   expect_true(is.numeric(df$x2))
   expect_true(is.list(or$x))
-  expect_equal(names(or$x), names(par.set$pars))
+  expect_equal(names(or$x), names(testp.fsphere.2d$pars))
   expect_equal(length(or$models[[1]]$subset), 15L)
 
+  f = testf.fsphere.2d
   par.set = makeParamSet(
     makeNumericParam("x1", lower = -2, upper = 1),
     makeIntegerParam("x2", lower = -1, upper = 2)
@@ -33,7 +25,7 @@ test_that("mbo works with km", {
   f = setAttribute(f, "par.set", par.set)
 
   des = generateTestDesign(10L, par.set = smoof::getParamSet(f))
-  des$y  = sapply(1:nrow(des), function(i) f(as.list(des[i, ])))
+  des$y = apply(des, 1, f)
   or = mbo(f, des, learner, ctrl)
   expect_true(!is.na(or$y))
   expect_equal(getOptPathLength(or$opt.path), 15L)
@@ -59,25 +51,17 @@ test_that("mbo works with km", {
 
 
 test_that("mbo works with impute and failure model", {
-  f = makeSingleObjectiveFunction(
-    fn = function(x) sum(x^2),
-    par.set = makeParamSet(
-      makeNumericParam("x1", lower = -2, upper = 1),
-      makeNumericParam("x2", lower = -1, upper = 2)
-    )
-  )
-  des = generateTestDesign(10, par.set = smoof::getParamSet(f))
+  des = testd.fsphere.2d
   # add same point twice with differnent y-vals - will crash km without nugget for sure
   des = rbind(des, data.frame(x1 = c(0, 0), x2 = c(0, 0)))
-  y  = sapply(1:nrow(des), function(i) f(as.list(des[i, ])))
-  y[length(y)] = 123
-  des$y = y
+  des$y = apply(des, 1, testf.fsphere.2d)
+  des$y[nrow(des)] = 123
   # make sure model does not break, and we get a failure model
   learner = makeLearner("regr.km", config = list(on.learner.error = "quiet"))
   ctrl = makeMBOControl()
   ctrl = setMBOControlTermination(ctrl, iters = 2L)
   ctrl = setMBOControlInfill(ctrl, opt.focussearch.points = 10L)
-  or = mbo(f, des, learner = learner, control = ctrl)
+  or = mbo(testf.fsphere.2d, des, learner = learner, control = ctrl)
   expect_equal(getOptPathLength(or$opt.path), 14)
   op = as.data.frame(or$opt.path)
   expect_true(!is.na(op$error.model[13L]))

--- a/tests/testthat/test_multipoint_cb.R
+++ b/tests/testthat/test_multipoint_cb.R
@@ -1,62 +1,27 @@
 context("multipoint cb")
 
 test_that("multipoint cb", {
-  par.set = makeNumericParamSet(len = 1L, lower = -1, upper = 1)
-  f = makeSingleObjectiveFunction(
-    fn = function(x) {
-      sum(x^2)
-    },
-    par.set = par.set
-  )
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
-
-  des = generateTestDesign(30L, smoof::getParamSet(f))
   ctrl = makeMBOControl(propose.points = 5L)
-  ctrl = setMBOControlTermination(ctrl, iters = 1L)
-  ctrl = setMBOControlInfill(ctrl, crit = "cb", opt = "focussearch", opt.focussearch.points = 100L,
-    opt.focussearch.maxit = 2L)
+  ctrl = setMBOControlTermination(ctrl, iters = 2L)
+  ctrl = setMBOControlInfill(ctrl, crit = "cb", opt = "focussearch", opt.focussearch.points = 100L, opt.focussearch.maxit = 2L)
   ctrl = setMBOControlMultiPoint(ctrl, method = "cb")
 
-  res = mbo(f, des, learner = lrn, control = ctrl)
+  res = mbo(testf.fsphere.1d, testd.fsphere.1d, learner = default.kriging, control = ctrl)
   op = as.data.frame(res$opt.path)
-  expect_true(all(is.na(op$multipoint.cb.lambda[1:30])))
-  expect_true(all(!is.na(op$multipoint.cb.lambda[31:35])))
+  expect_true(all(is.na(op$multipoint.cb.lambda[1:5])))
+  expect_true(all(!is.na(op$multipoint.cb.lambda[6:15])))
   expect_is(res, "MBOResult")
   expect_true(res$y < 0.1)
-
-  # FIXME: this test must be generalized
-  # now check min dist, set to "inf" so we can only propose 1 new point, not 5
-  des = generateTestDesign(30L, smoof::getParamSet(f))
-  ctrl = makeMBOControl(propose.points = 5L)
-  ctrl = setMBOControlTermination(ctrl, iters = 1L)
-  ctrl = setMBOControlInfill(ctrl, crit = "cb", opt = "focussearch", opt.focussearch.points = 100L,
-    opt.focussearch.maxit = 2L)
-  ctrl = setMBOControlMultiPoint(ctrl, method = "cb")
-  ctrl$cb.min.dist = 10000
-
-  res = mbo(f, des, learner = lrn, control = ctrl)
-  expect_equal(getOptPathLength(res$opt.path), 35L)
 })
 
 
 test_that("multipoint cb with random interleaved points", {
-  par.set = makeNumericParamSet(len = 1L, lower = -1, upper = 1)
-  f = makeSingleObjectiveFunction(
-    fn = function(x) {
-      sum(x^2)
-    },
-    par.set = par.set
-  )
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
-
-  des = generateTestDesign(30L, smoof::getParamSet(f))
   ctrl = makeMBOControl(propose.points = 5L)
   ctrl = setMBOControlTermination(ctrl, iters = 1L)
   ctrl = setMBOControlInfill(ctrl, crit = "cb", opt = "focussearch", opt.focussearch.points = 100L,
     opt.focussearch.maxit = 2L, interleave.random.points = 5L)
   ctrl = setMBOControlMultiPoint(ctrl, method = "cb")
-
-  res = mbo(f, des, learner = lrn, control = ctrl)
+  res = mbo(testf.fsphere.1d, testd.fsphere.1d, learner = default.kriging, control = ctrl)
   op = as.data.frame(res$opt.path)
   op = tail(op, 10)
 
@@ -74,16 +39,13 @@ test_that("multipoint cb with random interleaved points", {
   expect_true(all(!is.na(head(op$propose.time, 5))))
   expect_true(all(is.na(tail(op$propose.time, 5))))
 
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
-
-  des = generateTestDesign(30L, smoof::getParamSet(f))
   ctrl = makeMBOControl(propose.points = 1L)
   ctrl = setMBOControlTermination(ctrl, iters = 1L)
   ctrl = setMBOControlInfill(ctrl, crit = "cb", opt = "focussearch", opt.focussearch.points = 100L,
     opt.focussearch.maxit = 2L, interleave.random.points = 1L)
   ctrl = setMBOControlMultiPoint(ctrl, method = "cb")
 
-  res = mbo(f, des, learner = lrn, control = ctrl)
+  res = mbo(testf.fsphere.1d, testd.fsphere.1d, learner = default.kriging, control = ctrl)
   op = as.data.frame(res$opt.path)
   op = tail(op, 2)
   expect_identical(is.na(op$cb), c(FALSE, TRUE))

--- a/tests/testthat/test_multipoint_cl.R
+++ b/tests/testthat/test_multipoint_cl.R
@@ -1,22 +1,12 @@
 context("multipoint constant liar")
 
 test_that("multipoint constant liar", {
-  f = makeSingleObjectiveFunction(
-    fn = function(x) {
-      sum(x^2)
-    },
-    par.set = makeNumericParamSet(len = 1L, lower = -1, upper = 1)
-  )
-
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
-
-  des = generateTestDesign(30L, smoof::getParamSet(f))
   ctrl = makeMBOControl(propose.points = 5L)
-  ctrl = setMBOControlTermination(ctrl, iters = 1L)
+  ctrl = setMBOControlTermination(ctrl, iters = 2L)
   ctrl = setMBOControlInfill(ctrl, crit = "ei")
   ctrl = setMBOControlMultiPoint(ctrl, method = "cl")
-
-  res = mbo(f, des, learner = lrn, control = ctrl)
+  res = mbo(testf.fsphere.1d, testd.fsphere.1d, learner = default.kriging, control = ctrl)
   expect_is(res, "MBOResult")
   expect_true(res$y < 0.1)
+  expect_equal(getOptPathDOB(res$opt.path), rep(0:2, each = 5))
 })

--- a/tests/testthat/test_multipoint_multicrit.R
+++ b/tests/testthat/test_multipoint_multicrit.R
@@ -3,7 +3,6 @@ context("multipoint multicrit")
 test_that("multipoint multicrit", {
   f = makeBraninFunction()
   f = setAttribute(f, "par.set", makeNumericParamSet(len = 2L, lower = 0, upper = 1))
-  lrn = makeLearner("regr.km", predict.type = "se", covtype = "matern3_2")
 
   #FIXME how can we test this better?
   for (obj in c("ei.dist", "mean.se", "mean.se.dist")) {
@@ -21,7 +20,7 @@ test_that("multipoint multicrit", {
           multicrit.maxit = 30L
         )
 
-        res = mbo(f, des, learner = lrn, control = ctrl)
+        res = mbo(f, des, learner = default.kriging, control = ctrl)
 
         gap = res$y - 0.3979
         #expect_true(gap < 0.1)


### PR DESCRIPTION
Note: `cb.min.dist` was deleted because this feature simply does not exist
Also I made the multipoint tests run for 2 iterations to be safe