### PR TITLE
rng only on CRAN and removed run-all

### DIFF
--- a/tests/run-all.R
+++ b/tests/run-all.R
@@ -1,8 +1,0 @@
-library(testthat)
-library(mlrMBO)
-library(checkmate)
-
-seed.val = sample(1:100, size = 1)
-set.seed(seed.val)
-catf("Run test with seed: %i", seed.val)
-test_check("mlrMBO")

--- a/tests/testthat/helper_zzz.R
+++ b/tests/testthat/helper_zzz.R
@@ -1,6 +1,10 @@
-# if (!identical(Sys.getenv("TRAVIS"), "true"))
-#   set.seed(1)
-#FIXME: We shouldn't need to seed at all, see 
-set.seed(1)
+if (!is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
+  set.seed(1)
+} else {
+  seed.val = sample(1:100, size = 1)
+  set.seed(seed.val)
+  catf("Run test with seed: %i", seed.val)
+}
+
 configureMlr(show.learner.output = FALSE)
 options(mlrMBO.show.info = FALSE, mlrMBO.debug.mode = TRUE)

--- a/tests/testthat/helper_zzz.R
+++ b/tests/testthat/helper_zzz.R
@@ -1,7 +1,9 @@
+# We want to run on cran with a fixed seed (1) so that tests will not fail stochastically
+# For local testing + Travis we want to detect and be able reproduce these so we sample a seed 
 if (!is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
   set.seed(1)
 } else {
-  seed.val = sample(1:100, size = 1)
+  seed.val = sample(1:5, size = 1)
   set.seed(seed.val)
   catf("Run test with seed: %i", seed.val)
 }


### PR DESCRIPTION
See #238 

It's kind of hard to test if the `NOT_CRAN` thing is really working. But the code is identical to `devtools::r_get_env_vars()`.

Do we want to run our tests to always run reproducible? If so we can always print a seed like `run-all.R` did.

Other question: In  `test_multifid` and `test_plotEAF` a seed is hardcoded. Should we remove that? Or is there is special reason to do this even if we are not testing on CRAN? 
