### PR TITLE
add gg.objects to renderExampleRun functions

### DIFF
--- a/R/plotExampleRun.R
+++ b/R/plotExampleRun.R
@@ -61,6 +61,8 @@
 #'   each element a color for the type design, prop and seq respectivly.
 #'   Default is red for the initial design, blue for allready proposed points
 #'   and green for the actual iteration.
+#' @param gg.objects [\code{list)}]
+#'   List of \code{gg} objects that should be added to all ggplots.
 #' @param ... [any]\cr
 #'   Currently not used.
 #' @return Nothing.
@@ -69,7 +71,7 @@ plotExampleRun = function(object, iters, pause = TRUE,
   densregion = TRUE, se.factor = 1, single.prop.point.plots = FALSE,
   xlim = NULL, ylim = NULL,
   point.size = 3, line.size = 1,
-  trafo = NULL, colors = c("red", "blue", "green"), ...) {
+  trafo = NULL, colors = c("red", "blue", "green"), gg.objects = list(), ...) {
 
   iters.max = object$control$iters
   if (missing(iters)) {
@@ -92,6 +94,7 @@ plotExampleRun = function(object, iters, pause = TRUE,
   # Helper to arrange plot via gridExtra and pause process
   arrangePlots = function(plots, multi.crit) {
     plots = Filter(Negate(isScalarNA), plots)
+    plots = lapply(plots, addGgsToGgplot, gg.objects)
     n.plots = length(plots)
     if (n.plots > 1) {
       requirePackages("gridExtra", why = "plotExampleRun")
@@ -113,7 +116,7 @@ plotExampleRun = function(object, iters, pause = TRUE,
     # get rendered plot data
     plots = renderExampleRunPlot(object, iter = iter, densregion = densregion, se.factor = se.factor,
       single.prop.point.plots = single.prop.point.plots, xlim = xlim, ylim = ylim,
-      point.size = point.size, line.size = line.size, trafo = trafo, colors = colors, ...)
+      point.size = point.size, line.size = line.size, trafo = trafo, colors = colors, gg.objects = gg.objects, ...)
     if (!any(vlapply(plots, inherits, what = "ggplot"))) {
       # in this case we have multicrit multipoint proposal: list of plots for each proposed point
       for (jter in 1:length(plots)) {

--- a/R/renderExampleRunPlot_helpers.R
+++ b/R/renderExampleRunPlot_helpers.R
@@ -160,3 +160,15 @@ addParegoWeightLines = function(pl, data.y, idx, opt.path, proposed.counter, rho
   #   pl + geom_line(data = gg.line, aes(x = y1, y = y2), col = "blue", shape = 1)
   pl
 }
+
+# @param g [ggplot object]
+#   A normal ggplot object
+# @ggs [various ggplot objects]
+#   Elements that you want to add to ggplot as custom scales or themes
+addGgsToGgplot = function(g, ggs) {
+  if (!inherits(g, "gg")) return(g) #sometimes there are NAs
+  for (gg in ggs) {
+    g = g + gg
+  }
+  return(g)
+}

--- a/inst/examples/ex_1d_discrete_noisy.R
+++ b/inst/examples/ex_1d_discrete_noisy.R
@@ -42,4 +42,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn, control = ctrl,
 	points.per.dim = 50L, show.info = TRUE)
 
 print(run)
-plotExampleRun(run, pause = pause, densregion = TRUE)
+plotExampleRun(run, pause = pause, densregion = TRUE, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_1d_noisy_numeric.R
+++ b/inst/examples/ex_1d_noisy_numeric.R
@@ -38,4 +38,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn,
 
 print(run)
 
-plotExampleRun(run, pause = pause, densregion = TRUE)
+plotExampleRun(run, pause = pause, densregion = TRUE, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_1d_noisy_numeric_multifid.R
+++ b/inst/examples/ex_1d_noisy_numeric_multifid.R
@@ -51,4 +51,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn,
 
 print(run)
 
-res = plotExampleRun(run, pause = pause, densregion = TRUE)
+res = plotExampleRun(run, pause = pause, densregion = TRUE, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_1d_numeric.R
+++ b/inst/examples/ex_1d_numeric.R
@@ -26,4 +26,4 @@ design = generateDesign(6L, getParamSet(obj.fun), fun = lhs::maximinLHS)
 run = exampleRun(obj.fun, design = design, learner = lrn,
   control = ctrl, points.per.dim = 100, show.info = TRUE)
 
-plotExampleRun(run, pause = pause, densregion = TRUE)
+plotExampleRun(run, pause = pause, densregion = TRUE, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_1d_numeric_multipoint.R
+++ b/inst/examples/ex_1d_numeric_multipoint.R
@@ -34,4 +34,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn,
 
 print(run)
 
-plotExampleRun(run, pause = pause, densregion = TRUE)
+plotExampleRun(run, pause = pause, densregion = TRUE, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_2d_numeric.R
+++ b/inst/examples/ex_2d_numeric.R
@@ -24,4 +24,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn, control = ctrl,
 
 print(run)
 
-plotExampleRun(run, pause = pause)
+plotExampleRun(run, pause = pause, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_2d_numeric_multipoint.R
+++ b/inst/examples/ex_2d_numeric_multipoint.R
@@ -27,4 +27,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn, control = ctrl,
 
 print(run)
 
-plotExampleRun(run, pause = pause)
+plotExampleRun(run, pause = pause, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_mixed.R
+++ b/inst/examples/ex_mixed.R
@@ -35,4 +35,4 @@ run = exampleRun(obj.fun, design = design, learner = lrn,
 
 print(run)
 
-plotExampleRun(run, pause = pause, densregion = TRUE)
+plotExampleRun(run, pause = pause, densregion = TRUE, gg.objects = list(theme_bw()))

--- a/inst/examples/ex_multicrit.R
+++ b/inst/examples/ex_multicrit.R
@@ -21,4 +21,4 @@ design = generateDesign(5L, getParamSet(obj.fun), fun = lhs::maximinLHS)
 run = exampleRunMultiCrit(obj.fun, design = design, learner = learner, ctrl, points.per.dim = 50L,
   show.info = TRUE, nsga2.args = list())
 
-plotExampleRun(run, pause = pause)
+plotExampleRun(run, pause = pause, gg.objects = list(theme_bw()))

--- a/man/plotExampleRun.Rd
+++ b/man/plotExampleRun.Rd
@@ -7,7 +7,7 @@
 plotExampleRun(object, iters, pause = TRUE, densregion = TRUE,
   se.factor = 1, single.prop.point.plots = FALSE, xlim = NULL,
   ylim = NULL, point.size = 3, line.size = 1, trafo = NULL,
-  colors = c("red", "blue", "green"), ...)
+  colors = c("red", "blue", "green"), gg.objects = list(), ...)
 }
 \arguments{
 \item{object}{[\code{function}]\cr
@@ -68,6 +68,9 @@ Specify colors for point in the plots. Must be a vector of length 3,
 each element a color for the type design, prop and seq respectivly.
 Default is red for the initial design, blue for allready proposed points
 and green for the actual iteration.}
+
+\item{gg.objects}{[\code{list)}]
+List of \code{gg} objects that should be added to all ggplots.}
 
 \item{...}{[any]\cr
 Currently not used.}


### PR DESCRIPTION
This is very helpful if you want to modify the plots a bit (e.g. for publications). 
You can now pass different ggplot2 objects that will be added to each plot. 
Personally I favor `theme_bw()` which I now can easily apply to the MBO plots.