### PR TITLE
add function to check for constant model while focussearch

### DIFF
--- a/R/getExtras.R
+++ b/R/getExtras.R
@@ -61,6 +61,12 @@ getExtras = function(n, prop, train.time, control) {
     if (control$filter.proposed.points) {
       ex$filter.replace = prop$filter.replace[i]
     }
+    if (isTRUE(attr(prop$prop.points, "constant.model"))) {
+      ex$constant.model = TRUE
+    } else {
+      ex$constant.model = FALSE
+    }
+    # if we use asyn MBO store node information and evaluation starte
     ex$train.time = if (i == 1) train.time else NA_real_
     ex$prop.type = prop$prop.type[i]
     ex$propose.time = NA_real_

--- a/R/infillOptFocus.R
+++ b/R/infillOptFocus.R
@@ -24,10 +24,19 @@ infillOptFocus = function(infill.crit, models, control, par.set, opt.path, desig
       y = infill.crit(newdesign, models, control, ps.local, design, iter, ...)
 
       # get current best value
-      local.index = getMinIndex(y, ties.method = "random")
+      local.index = getMinIndex(y, ties.method = "random", na.rm = TRUE)
       local.y = y[local.index]
       local.x.df = newdesign[local.index, , drop = FALSE]
       local.x.list = dfRowToList(recodeTypes(local.x.df, ps.local), ps.local, 1)
+
+      # we want to stop early if the model just proposes constant values (Kriging!)
+      if (control$check.constant.model) {
+        if (length(unique(y)) == 1) {
+          res = recodeTypes(local.x.df, par.set)
+          attr(res, "constant.model") = TRUE
+          return(res)
+        }
+      }
 
       # if we found a new best value, store it
       if (local.y < global.y) {

--- a/R/makeMBOControl.R
+++ b/R/makeMBOControl.R
@@ -73,6 +73,9 @@
 #'   Default is \code{\link[mlr]{mse}}.
 #' @param output.num.format [\code{logical(1)}]\cr
 #'   Format string for the precision of the numeric output of mbo.
+#' @param check.constant.model \code{logical(1)}\cr
+#'    Should we check if the model just proposes constant values after each model build.
+#'    (Only works for Focussearch for now)
 #' @return [\code{\link{MBOControl}}].
 #' @aliases MBOControl
 #' @family MBOControl
@@ -91,7 +94,8 @@ makeMBOControl = function(n.objectives = 1L,
   resample.at = integer(0),
   resample.desc = makeResampleDesc("CV", iter = 10),
   resample.measures = list(mse),
-  output.num.format = "%.3g"
+  output.num.format = "%.3g",
+  check.constant.model = FALSE
 ) {
 
   n.objectives = asInt(n.objectives, lower = 1L)
@@ -122,7 +126,8 @@ makeMBOControl = function(n.objectives = 1L,
   assertList(resample.measures, types = "Measure")
 
   assertString(output.num.format)
-
+  assertFlag(check.constant.model)
+ 
   control = makeS3Obj("MBOControl",
     n.objectives = n.objectives,
     propose.points = propose.points,
@@ -140,6 +145,7 @@ makeMBOControl = function(n.objectives = 1L,
     resample.at = resample.at,
     resample.measures = resample.measures,
     output.num.format = output.num.format,
+    check.constant.model = check.constant.model,
     multifid = FALSE
   )
 

--- a/man/makeMBOControl.Rd
+++ b/man/makeMBOControl.Rd
@@ -12,7 +12,8 @@ makeMBOControl(n.objectives = 1L, propose.points = 1L,
   save.file.path = file.path(getwd(), "mlr_run.RData"),
   store.model.at = NULL, resample.at = integer(0),
   resample.desc = makeResampleDesc("CV", iter = 10),
-  resample.measures = list(mse), output.num.format = "\%.3g")
+  resample.measures = list(mse), output.num.format = "\%.3g",
+  check.constant.model = FALSE)
 }
 \arguments{
 \item{n.objectives}{[\code{integer(1)}]\cr
@@ -100,6 +101,10 @@ Default is \code{\link[mlr]{mse}}.}
 
 \item{output.num.format}{[\code{logical(1)}]\cr
 Format string for the precision of the numeric output of mbo.}
+
+\item{check.constant.model}{\code{logical(1)}\cr
+Should we check if the model just proposes constant values after each model build.
+(Only works for Focussearch for now)}
 }
 \value{
 [\code{\link{MBOControl}}].

--- a/tests/testthat/test_mbo_km.R
+++ b/tests/testthat/test_mbo_km.R
@@ -67,3 +67,17 @@ test_that("mbo works with impute and failure model", {
   expect_true(!is.na(op$error.model[13L]))
   expect_true(!is.na(op$error.model[14L]))
 })
+
+test_that("mbo recognizes constant model prediction", {
+  des = testd.fsphere.2d
+  des$y = mean(apply(des, 1, testf.fsphere.2d))
+  # make sure model does not break, and we get a failure model
+  learner = makeLearner("regr.km")
+  ctrl = makeMBOControl(check.constant.model = TRUE)
+  ctrl = setMBOControlTermination(ctrl, iters = 4L)
+  ctrl = setMBOControlInfill(ctrl, opt.focussearch.points = 100L)
+  or = mbo(testf.fsphere.2d, des, learner = learner, control = ctrl)
+  expect_equal(getOptPathLength(or$opt.path), 14)
+  op = as.data.frame(or$opt.path)
+  expect_true(sum(op$constant.model)<5)
+})


### PR DESCRIPTION
Deals with #258
adds another column to the opt path where it saves whether the predictions were constant.
also finishes focussearch earlier.