### PR TITLE
add basic printer for OptState and OptProblem

### DIFF
--- a/R/OptProblem.R
+++ b/R/OptProblem.R
@@ -101,3 +101,10 @@ setOptProblemDesign = function(opt.problem, design) {
 getOptProblemDesign = function(opt.problem) {
   opt.problem$design
 }
+
+print.OptProblem = function(opt.problem) {
+  catf("OptProblem")
+  catf("Objective Function: %s", getName(getOptProblemFun()))
+  catf("Surrogate Learner:")
+  print(getOptProblemLearner(opt.problem))
+} 

--- a/R/OptState.R
+++ b/R/OptState.R
@@ -118,3 +118,14 @@ makeOptStateMboResult = function(opt.state) {
   setOptResultMboResult(opt.result, mbo.result)
   mbo.result
 }
+
+print.OptState = function(opt.state) {
+  catf("OptSate")
+  catf("Actual state: %s", getOptStateState(opt.state))
+  catf("Actual loop: %i", getOptStateLoop(opt.state))
+  catf("Loop started:%s", opt.state$loop.starttime)
+  catf("")
+  print(getOptStateOptProblem(opt.state))
+  catf("")
+  print(getOptStateOptPath(opt.state))
+}

--- a/man/makeMboLearner.Rd
+++ b/man/makeMboLearner.Rd
@@ -14,19 +14,22 @@ Control object for mbo.}
 The same objective function which is also passed to \code{\link{mbo}}.}
 
 \item{...}{[any]\cr
-Parameters passed to \code{\link[DiceKriging]{km}}.
+Parameters passed to \code{par.vals}.
 Will overwrite mlrMBOs recomendations.}
 }
 \value{
 [\code{Learner}]
 }
 \description{
-This is a helper function that generates the right learner for the surrogate based on criteria of the objective function.
-For numeric only parameter spaces: \cr
+This is a helper function that generates the right learner for the surrogate, based on criteria of the objective function.
+For numeric only parameter spaces it returns a Kriging regression learner with the following settings: \cr
 If the objective function is noisy the nugget effect will be estimated unless \code{nugget.estim = FALSE} is explicitly given in \code{...}.
 Also \code{jitter} is set to \code{TRUE} to circumvent a problem with DiceKriging where already trained input values produce the exact trained output.
 For further informations check the \code{$note} slot of the created learner.
 If the objective function is deterministic we add a small nugget effect to increase numerical stability which prevents crashes of DiceKriging. 
+The nugget effect is set to 10^-8 * Var(y) on each model training.
 For mixed parameter spaces the function returns a random forest regression learner.
+The method to estimate the variance is the standard deviation of the bagged predictions.
+You can override this setting in \code{...}.
 }
 


### PR DESCRIPTION
This was requested by @berndbischl some day (in #205)
But as the OptState is never visible to the user I don't know where is the best place to test it.
Also I am not completely sure what information should be printed. What information you want is probably quite different from situation to situation.