### PR TITLE
remove plyr & some suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     ggplot2,
     RColorBrewer,
     parallelMap (>= 1.1),
-    plyr,
     reshape2
 Suggests:
     akima,
@@ -34,11 +33,9 @@ Suggests:
     DiceOptim,
     earth,
     emoa,
-    GGally,
     gridExtra,
     kernlab,
     kknn,
-    mboost,
     mco,
     nnet,
     party,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,10 +22,10 @@ Imports:
     backports,
     BBmisc (>= 1.7),
     checkmate (>= 1.8.1),
+    data.table,
     ggplot2,
     RColorBrewer,
-    parallelMap (>= 1.1),
-    reshape2
+    parallelMap (>= 1.1)
 Suggests:
     akima,
     cmaes,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     DiceOptim,
     earth,
     emoa,
+    GGally,
     gridExtra,
     kernlab,
     kknn,

--- a/R/renderExampleRunPlotSingleCrit1d.R
+++ b/R/renderExampleRunPlotSingleCrit1d.R
@@ -104,12 +104,12 @@ renderExampleRunPlot1d = function(x, iter,
     }
     # prepare drawing of standard error (confidence interval)
     if (se) {
-      evals$se = -infillCritStandardError(evals.x, list(model), control, par.set, convertOptPathToDf(opt.path, control)[idx.past, ])
+      evals$se = -infillCritStandardError(evals.x, list(model), control, par.set, convertOptPathToDf(opt.path, control)[idx.past,, drop = FALSE])
     }
   }
 
   if (isNumeric(par.set, include.int = FALSE)) {
-    gg.fun = reshape2::melt(evals, id.vars = c(getParamIds(opt.path$par.set), if (se) "se" else NULL))
+    gg.fun = data.table::setDF(data.table::melt(evals, id.vars = c(getParamIds(opt.path$par.set), if (se) "se" else NULL)))
 
     if (control$multifid) {
       #rename .multifid.lvl according to control object

--- a/R/renderExampleRunPlotSingleCrit1d.R
+++ b/R/renderExampleRunPlotSingleCrit1d.R
@@ -115,7 +115,8 @@ renderExampleRunPlot1d = function(x, iter,
       #rename .multifid.lvl according to control object
       repl = paste0(control$multifid.param, "=", control$multifid.lvls)
       names(repl) = as.character(seq_along(control$multifid.lvls))
-      gg.fun$.multifid.lvl = plyr::revalue(as.factor(gg.fun$.multifid.lvl), replace = repl)
+      #gg.fun$.multifid.lvl = plyr::revalue(as.factor(gg.fun$.multifid.lvl), replace = repl)
+      gg.fun$.multifid.lvl = factor(gg.fun$.multifid.lvl, labels = repl)
     }
 
     if (se) gg.fun$se = gg.fun$se * se.factor


### PR DESCRIPTION
We could also remove `reshape2` since it is only required in one line but using the base reshape is really annoying.

Most of the packages in suggest (earth, kknn, kernlab, nnet) are only used in one test file