### PR TITLE
Fix253: Forbid final.method and final.evals for multi.crit

### DIFF
--- a/R/checkStuff.R
+++ b/R/checkStuff.R
@@ -28,6 +28,12 @@ checkStuff = function(fun, par.set, design, learner, control) {
     stopf("Optimization of noisy multi-objective functions not supported in the moment.")
   }
 
+  # final.method and final.evals have no effect on multicriteria optimization
+  if (getNumberOfObjectives(fun) > 1L &&
+      (control$final.method != "best.true.y" || control$final.evals > 0L)) {
+    stopf("Setting of final.method and final.evals for multicriteria optimization not supported at the moment.")
+  }
+
   # general parameter and learner checks
   if (any(vlapply(par.set$pars, inherits, what = "LearnerParam")))
     stop("No parameter can be of class 'LearnerParam'! Use basic parameters instead to describe you region of interest!")

--- a/R/checkStuff.R
+++ b/R/checkStuff.R
@@ -31,7 +31,7 @@ checkStuff = function(fun, par.set, design, learner, control) {
   # final.method and final.evals have no effect on multicriteria optimization
   if (getNumberOfObjectives(fun) > 1L &&
       (control$final.method != "best.true.y" || control$final.evals > 0L)) {
-    stopf("Setting of final.method and final.evals for multicriteria optimization not supported at the moment.")
+    stop("Setting of final.method and final.evals for multicriteria optimization not supported at the moment.")
   }
 
   # general parameter and learner checks


### PR DESCRIPTION
Fix #253: For the moment, just throw an error for these settings.

As discussed, the real code should be added later, when we add support for noisy multi crit.