### PR TITLE
Fix se infillCrit

### DIFF
--- a/R/getInfillCritFunction.R
+++ b/R/getInfillCritFunction.R
@@ -18,7 +18,6 @@ getInfillCritFunction = function(infill.crit) {
     # mq  = makeMBOInfillCriterionMQ(),
     # eipi  =  makeMBOInfillCriterionEIPI(),
     dib = makeMBOInfillCriterionDIB(),
-    #multifid = makeMBOInfillCriterionMultiFid(),
-    match.fun(infill.crit)
+    #multifid = makeMBOInfillCriterionMultiFid()
   )
 }

--- a/R/getInfillCritFunction.R
+++ b/R/getInfillCritFunction.R
@@ -18,6 +18,7 @@ getInfillCritFunction = function(infill.crit) {
     # mq  = makeMBOInfillCriterionMQ(),
     # eipi  =  makeMBOInfillCriterionEIPI(),
     dib = makeMBOInfillCriterionDIB(),
-    #multifid = makeMBOInfillCriterionMultiFid()
+    #multifid = makeMBOInfillCriterionMultiFid(),
+    match.fun(infill.crit)
   )
 }

--- a/R/infill_crits.R
+++ b/R/infill_crits.R
@@ -57,10 +57,10 @@ makeMBOInfillCriterionMeanResponse = function() {
 makeMBOInfillCriterionStandardError = function() {
   makeMBOInfillCriterion(
     fun = function(points, models, control, par.set, design, iter, attributes = FALSE) {
-      -predict(models[[1L]], newdata = points)$data$se
+      ifelse(control$minimize, 1, -1) * predict(models[[1L]], newdata = points)$data$se
     },
     name = "Standard error",
-    id = "sd",
+    id = "se",
     requires.se = TRUE
   )
 }

--- a/R/infill_crits.R
+++ b/R/infill_crits.R
@@ -57,10 +57,9 @@ makeMBOInfillCriterionMeanResponse = function() {
 makeMBOInfillCriterionStandardError = function() {
   makeMBOInfillCriterion(
     fun = function(points, models, control, par.set, design, iter, attributes = FALSE) {
-       predict(models[[1L]], newdata = points)$data$se
+       -predict(models[[1L]], newdata = points)$data$se
     },
     name = "Standard error",
-    minimize = FALSE,
     id = "se",
     requires.se = TRUE
   )

--- a/R/infill_crits.R
+++ b/R/infill_crits.R
@@ -57,9 +57,10 @@ makeMBOInfillCriterionMeanResponse = function() {
 makeMBOInfillCriterionStandardError = function() {
   makeMBOInfillCriterion(
     fun = function(points, models, control, par.set, design, iter, attributes = FALSE) {
-      ifelse(control$minimize, 1, -1) * predict(models[[1L]], newdata = points)$data$se
+       predict(models[[1L]], newdata = points)$data$se
     },
     name = "Standard error",
+    minimize = FALSE,
     id = "se",
     requires.se = TRUE
   )

--- a/tests/testthat/test_infillcrits.R
+++ b/tests/testthat/test_infillcrits.R
@@ -48,7 +48,7 @@ test_that("infill crits", {
   # we have converged and just waste time. we need to detect this somehow, or cope with it
   for (noisy in c(TRUE, FALSE)) {
     for (minimize in c(TRUE, FALSE)) {
-      crits = if (noisy) list(crit.aei, crit.eqi) else list(crit.mr, crit.ei)
+      crits = if (noisy) list(crit.aei, crit.eqi) else list(crit.mr, crit.se, crit.ei)
       for (lrn in learners) {
         if (inherits(lrn, "regr.km"))
           lrn = setHyperPars(lrn, nugget.estim = noisy)


### PR DESCRIPTION
See #325 

What happened:

- `getInfillCritFunction` has a `match.fun` argument (I guess for user defined criteria).
- The id of `makeMBOInfillCriterionStandardError` was set to `sd` instead of `se`
- Well as `sd` is a valid function in R, `getInfillCritFunction` matched that and returned the sd function.

Is fixed now and we also test `makeMBOInfillCriterionStandardError` in the tests now...

EDIT: 

Maybe we should add a check in the end of `getInfillCritFunction`, that the object returned by match.fun has class `"MBOInfillCriterion"`