### PR TITLE
Fix 333 lambdadefault

### DIFF
--- a/R/checkStuff.R
+++ b/R/checkStuff.R
@@ -61,9 +61,11 @@ checkStuff = function(fun, par.set, design, learner, control) {
   }
   
   # set default lambda parameter for cb infill crit
-  if (infill.crit.id == "cb" && is.null(control$infill.crit$params$cb.lambda))
-    control$infill.crit = makeMBOInfillCriterionCB(ifelse(isNumeric(par.set, include.int = TRUE), 1, 2))
-  
+  if (infill.crit.id == "cb" && is.null(control$infill.crit$params$cb.lambda)) {
+    lambda = ifelse(isNumeric(par.set, include.int = TRUE), 1, 2)
+    control$infill.crit = makeMBOInfillCriterionCB()
+  }
+
   # If nugget estimation should be used, make sure learner is a km model with activated nugget estim
   if (infill.crit.id == "aei" && getMBOInfillCriterionParam(infill.crit, "aei.use.nugget")) {
     if (learner$short.name != "km" || !isTRUE(getHyperPars(learner)$nugget.estim)) {

--- a/R/checkStuff.R
+++ b/R/checkStuff.R
@@ -59,7 +59,11 @@ checkStuff = function(fun, par.set, design, learner, control) {
       ifelse(hasLearnerProperties(learner, "se"), "",
         "\nBut this learner does not seem to support prediction of standard errors! You could use the mlr wrapper makeBaggingWrapper to bootstrap the standard error estimator."))
   }
-
+  
+  # set default lambda parameter for cb infill crit
+  if (infill.crit.id == "cb" && is.null(control$infill.crit$params$cb.lambda))
+    control$infill.crit$params$cb.lambda = ifelse(isNumeric(par.set, include.int = TRUE), 1, 2)
+  
   # If nugget estimation should be used, make sure learner is a km model with activated nugget estim
   if (infill.crit.id == "aei" && getMBOInfillCriterionParam(infill.crit, "aei.use.nugget")) {
     if (learner$short.name != "km" || !isTRUE(getHyperPars(learner)$nugget.estim)) {
@@ -75,7 +79,7 @@ checkStuff = function(fun, par.set, design, learner, control) {
     control$infill.opt.ea.mu = coalesce(control$infill.opt.ea.mu, getNumberOfParameters(fun) * 10L)
     assertNumber(control$infill.opt.ea.mu, na.ok = FALSE, lower = 0)
   }
-
+  
   if (is.null(control$target.fun.value)) {
     # If we minimize, target is -Inf, for maximize it is Inf
     control$target.fun.value = if (control$minimize[1L]) -Inf else Inf

--- a/R/checkStuff.R
+++ b/R/checkStuff.R
@@ -63,7 +63,7 @@ checkStuff = function(fun, par.set, design, learner, control) {
   # set default lambda parameter for cb infill crit
   if (infill.crit.id == "cb" && is.null(control$infill.crit$params$cb.lambda)) {
     lambda = ifelse(isNumeric(par.set, include.int = TRUE), 1, 2)
-    control$infill.crit = makeMBOInfillCriterionCB()
+    control$infill.crit = makeMBOInfillCriterionCB(cb.lambda = lambda)
   }
 
   # If nugget estimation should be used, make sure learner is a km model with activated nugget estim

--- a/R/checkStuff.R
+++ b/R/checkStuff.R
@@ -62,7 +62,7 @@ checkStuff = function(fun, par.set, design, learner, control) {
   
   # set default lambda parameter for cb infill crit
   if (infill.crit.id == "cb" && is.null(control$infill.crit$params$cb.lambda))
-    control$infill.crit$params$cb.lambda = ifelse(isNumeric(par.set, include.int = TRUE), 1, 2)
+    control$infill.crit = makeMBOInfillCriterionCB(ifelse(isNumeric(par.set, include.int = TRUE), 1, 2))
   
   # If nugget estimation should be used, make sure learner is a km model with activated nugget estim
   if (infill.crit.id == "aei" && getMBOInfillCriterionParam(infill.crit, "aei.use.nugget")) {

--- a/R/infill_crits.R
+++ b/R/infill_crits.R
@@ -103,7 +103,7 @@ makeMBOInfillCriterionEI = function(se.threshold = 1e-6) {
 
 #' @export
 #' @rdname infillcrits
-makeMBOInfillCriterionCB = function(cb.lambda = 1) {
+makeMBOInfillCriterionCB = function(cb.lambda = NULL) {
   assertNumber(cb.lambda, lower = 0, null.ok = TRUE)
   force(cb.lambda)
   makeMBOInfillCriterion(

--- a/R/infill_crits.R
+++ b/R/infill_crits.R
@@ -103,13 +103,11 @@ makeMBOInfillCriterionEI = function(se.threshold = 1e-6) {
 
 #' @export
 #' @rdname infillcrits
-makeMBOInfillCriterionCB = function(cb.lambda = NULL) {
+makeMBOInfillCriterionCB = function(cb.lambda = 1) {
   assertNumber(cb.lambda, lower = 0, null.ok = TRUE)
   force(cb.lambda)
   makeMBOInfillCriterion(
     fun = function(points, models, control, par.set, design, iter, attributes = FALSE) {
-      if (is.null(cb.lambda))
-        cb.lambda = ifelse(isNumeric(par.set, include.int = TRUE), 1, 2)
       model = models[[1L]]
       maximize.mult = ifelse(control$minimize, 1, -1)
       p = predict(model, newdata = points)$data

--- a/R/setMBOControlInfill.R
+++ b/R/setMBOControlInfill.R
@@ -10,8 +10,7 @@
 #' @param crit [\code{\link{MBOInfillCriterion}}]\cr
 #'   How should infill points be rated. See \code{\link{infillcrits}} for an overview
 #'   of available infill criteria or implement a custom one via \code{\link{makeMBOInfillCriterion}}.#
-#'   Default is \dQuote{(lower) confidence bound} (see \code{\link{makeMBOInfillCriterionCB}}) with 
-#'   \code{cb.lambda = 1} in case of a fully numeric parameter set and 2 otherwise.
+#'   Default is \dQuote{(lower) confidence bound} (see \code{\link{makeMBOInfillCriterionCB}}).
 #' @param interleave.random.points [\code{integer(1)}]\cr
 #'   Add \code{interleave.random.points} uniformly sampled points additionally to the
 #'   regular proposed points in each step.

--- a/R/setMBOControlInfill.R
+++ b/R/setMBOControlInfill.R
@@ -10,7 +10,8 @@
 #' @param crit [\code{\link{MBOInfillCriterion}}]\cr
 #'   How should infill points be rated. See \code{\link{infillcrits}} for an overview
 #'   of available infill criteria or implement a custom one via \code{\link{makeMBOInfillCriterion}}.#
-#'   Default is \dQuote{(lower) confidence bound} (see \code{\link{makeMBOInfillCriterionCB}}).
+#'   Default is \dQuote{(lower) confidence bound} (see \code{\link{makeMBOInfillCriterionCB}}) with 
+#'   \code{cb.lambda = 1} in case of a fully numeric parameter set and 2 otherwise.
 #' @param interleave.random.points [\code{integer(1)}]\cr
 #'   Add \code{interleave.random.points} uniformly sampled points additionally to the
 #'   regular proposed points in each step.


### PR DESCRIPTION
Fixed #333 we now define the lambda parameter in `checkstuff`

One multiobjective test is failing.

Specifically because of this line:

```
cb = evalCritFunForMultiObjModels(makeMBOInfillCriterionCB()$fun, prop$prop.points, models, control2,
        par.set, design, iter)[1L, ]
```
in `proposePointsDIB`.

I don't know much about the multiobjective stuff. The problem is that the makeMBOInfillCriterionCB is called without a lambda parameter but it is not used in an mbo call (so we do not run `checkstuff()`).

@danielhorn Does it matter what lambda is used there? As far as I can see the actual sampled lambda is passed in `control2`. Can you maybe have a look on how to fix this. 