### PR TITLE
make mlr on.learner.error an mlrmbo setting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# mlrMBO 1.1.1
+
+* `makeMBOControl()` has `on.surrogate.error` argument which enables random proposals if the surrogate model fails.
+* With `initSMBO()`, `updateSMBO()` and `finalizeSMBO()` it is now possible to do a human-in-the-loop MBO.
+* The result now contains the `final.opt.state`.
+
 # mlrMBO 1.1.0
 
 * Fixed bug in focus search that affected discrete search spaces.

--- a/R/checkLearner.R
+++ b/R/checkLearner.R
@@ -1,9 +1,10 @@
 # check and create default learner
 checkLearner = function(learner, control, fun) {
   if (missing(learner) || is.null(learner)) {
-    learner = makeMBOLearner(control, fun, config = list(show.learner.output = FALSE))
+    learner = makeMBOLearner(control, fun, config = list(show.learner.output = FALSE, on.learner.error = control$on.surrogate.error))
   } else {
     assertClass(learner, "Learner")
+    learner$config = insert(learner$config, list(on.learner.error = control$on.surrogate.error))
   }
   # so we dont run into problems with focus search et al
   learner$fix.factors.prediction = TRUE

--- a/R/makeMBOControl.R
+++ b/R/makeMBOControl.R
@@ -73,6 +73,14 @@
 #'   Default is \code{\link[mlr]{mse}}.
 #' @param output.num.format [\code{logical(1)}]\cr
 #'   Format string for the precision of the numeric output of mbo.
+#' @param on.surrogate.error [\code{character(1)}]\cr
+#'   What should happen when the surrogate learner can not train the model.
+#'   Possible values are:
+#'   \dQuote{stop}: R exception is generated.
+#'   \dQuote{warn}: The error will be converted to a waring and a random point will be proposed.
+#'   \dQuote{quiet}: Same as “warn” but without the warning.
+#'   Default is: \dQuote{stop}.
+#'   
 #' @return [\code{\link{MBOControl}}].
 #' @aliases MBOControl
 #' @family MBOControl
@@ -91,7 +99,8 @@ makeMBOControl = function(n.objectives = 1L,
   resample.at = integer(0),
   resample.desc = makeResampleDesc("CV", iter = 10),
   resample.measures = list(mse),
-  output.num.format = "%.3g"
+  output.num.format = "%.3g",
+  on.surrogate.error = "stop"
 ) {
 
   n.objectives = asInt(n.objectives, lower = 1L)
@@ -123,6 +132,8 @@ makeMBOControl = function(n.objectives = 1L,
 
   assertString(output.num.format)
 
+  assertChoice(on.surrogate.error, c("warn", "stop", "quiet"))
+
   control = makeS3Obj("MBOControl",
     n.objectives = n.objectives,
     propose.points = propose.points,
@@ -140,6 +151,7 @@ makeMBOControl = function(n.objectives = 1L,
     resample.at = resample.at,
     resample.measures = resample.measures,
     output.num.format = output.num.format,
+    on.surrogate.error = on.surrogate.error,
     multifid = FALSE
   )
 

--- a/man/makeMBOControl.Rd
+++ b/man/makeMBOControl.Rd
@@ -12,7 +12,8 @@ makeMBOControl(n.objectives = 1L, propose.points = 1L,
   save.file.path = file.path(getwd(), "mlr_run.RData"),
   store.model.at = NULL, resample.at = integer(0),
   resample.desc = makeResampleDesc("CV", iter = 10),
-  resample.measures = list(mse), output.num.format = "\%.3g")
+  resample.measures = list(mse), output.num.format = "\%.3g",
+  on.surrogate.error = "stop")
 }
 \arguments{
 \item{n.objectives}{[\code{integer(1)}]\cr
@@ -100,6 +101,14 @@ Default is \code{\link[mlr]{mse}}.}
 
 \item{output.num.format}{[\code{logical(1)}]\cr
 Format string for the precision of the numeric output of mbo.}
+
+\item{on.surrogate.error}{[\code{character(1)}]\cr
+What should happen when the surrogate learner can not train the model.
+Possible values are:
+\dQuote{stop}: R exception is generated.
+\dQuote{warn}: The error will be converted to a waring and a random point will be proposed.
+\dQuote{quiet}: Same as “warn” but without the warning.
+Default is: \dQuote{stop}.}
 }
 \value{
 [\code{\link{MBOControl}}].

--- a/tests/testthat/test_mbo_km.R
+++ b/tests/testthat/test_mbo_km.R
@@ -62,8 +62,8 @@ test_that("mbo works with impute and failure model", {
   des$y = apply(des, 1, testf.fsphere.2d)
   des$y[nrow(des)] = 123
   # make sure model does not break, and we get a failure model
-  learner = makeLearner("regr.km", config = list(on.learner.error = "quiet"))
-  ctrl = makeMBOControl()
+  learner = makeLearner("regr.km")
+  ctrl = makeMBOControl(on.surrogate.error = "quiet")
   ctrl = setMBOControlTermination(ctrl, iters = 2L)
   ctrl = setMBOControlInfill(ctrl, crit = crit.mr, opt.focussearch.points = 10L)
   or = mbo(testf.fsphere.2d, des, learner = learner, control = ctrl)


### PR DESCRIPTION
Now you can set `on.surrogate.error` in `makeMBOControl`.