### PR TITLE
allow impute function to set extras attribute

### DIFF
--- a/R/evalTargetFun.R
+++ b/R/evalTargetFun.R
@@ -84,6 +84,10 @@ evalTargetFun.OptState = function(opt.state, xs, extras) {
         if (!isYValid(y2))
           stopf("Y-Imputation failed. Must return a numeric of length: %i, but we got: %s",
             ny, convertToShortString(y2))
+        if (hasAttributes(y2, "extras")) {
+          user.extras = attr(y2, "extras")
+          y2 = setAttribute(y2, "extras", NULL)
+        }
       }
     }
 


### PR DESCRIPTION
Allow things like
```r
makeMBOControl(
    impute.y.fun = function(x, y, opt.path, ...) {
      structure(-log(1/4), extras = list(metainfo = 2))  # log loss of dumbest possible prediction for 4 classes (i.e. nucleotide prediction)
    }, ...
)
```
otherwise, setting extras attribute in the actual function gives an error whenever a value is imputed, since opt.path doesn't allow points to have missing "extra(s)" for individual points.